### PR TITLE
Fix Next.js config and add tests

### DIFF
--- a/content/work/fluent-icons.md
+++ b/content/work/fluent-icons.md
@@ -13,7 +13,7 @@ officialURLText: "View icon repository"
 hideFromList: false
 ---
 
-The Fluent UI Icons are a set of monoline icons from Microsoft, designed originally for mobile apps but with the web and desktop in mind. These icons are based on metaphors established by the older "MDL2" set originally conceived and widely used by the Windows team. They compliment the new [Fluent Design System](https://www.microsoft.com/design/fluent/) and the additional full-color app icon work undertaken by Office, Windows, and countless other teams across Microsoft.
+The Fluent UI Icons are a set of monoline icons from Microsoft, designed originally for mobile apps but with the web and desktop in mind. These icons are based on metaphors established by the older "MDL2" set originally conceived and widely used by the Windows team. They complement the new [Fluent Design System](https://www.microsoft.com/design/fluent/) and the additional full-color app icon work undertaken by Office, Windows, and countless other teams across Microsoft.
 
 I was part of a team spanning designers from across the company that laid the groundwork for this icon system. We were able to quickly scale the system from a handful of icons to thousands over a few months. Using an agile approach we were able to release new icons every week, prioritizing icons for teams that needed them immediately.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/lib/work.test.ts
+++ b/lib/work.test.ts
@@ -1,0 +1,27 @@
+import { getSortedWorkData } from './work';
+import fs from 'fs';
+
+jest.mock('fs');
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+
+describe('getSortedWorkData', () => {
+  it('returns posts sorted by date descending', () => {
+    mockedFs.readdirSync.mockReturnValue(['first.md', 'second.md', 'third.md']);
+
+    mockedFs.readFileSync.mockImplementation((filePath: any) => {
+      if (filePath.toString().includes('first.md')) {
+        return '---\ndate: "2021-01-01"\n---\nContent first';
+      }
+      if (filePath.toString().includes('second.md')) {
+        return '---\ndate: "2023-02-01"\n---\nContent second';
+      }
+      return '---\ndate: "2022-06-01"\n---\nContent third';
+    });
+
+    const result = getSortedWorkData();
+    const dates = result.map((r) => r.date);
+    expect(dates).toEqual(['2023-02-01', '2022-06-01', '2021-01-01']);
+    expect(result[0].id).toBe('second');
+  });
+});

--- a/lib/work.ts
+++ b/lib/work.ts
@@ -5,7 +5,7 @@ import matter from "gray-matter";
 const postsDirectory = path.join(process.cwd(), "content/work");
 
 export function getSortedWorkData() {
-    // Get file names under /posts
+    // Get file names under /work
     const fileNames = fs.readdirSync(postsDirectory);
 
     const allPostsData = fileNames.map((fileName) => {

--- a/next.config.js
+++ b/next.config.js
@@ -8,11 +8,8 @@ const withMDX = require("@next/mdx")({
     },
 });
 
-module.exports = withMDX({
+const nextConfig = {
     pageExtensions: ["ts", "tsx", "js", "jsx", "md", "mdx"],
-});
-
-module.exports = {
     async redirects() {
         return [
             {
@@ -125,3 +122,5 @@ module.exports = {
         return config;
     },
 };
+
+module.exports = withMDX(nextConfig);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "scripts": {
         "dev": "next dev",
         "build": "next build",
-        "start": "next start"
+        "start": "next start",
+        "test": "jest"
     },
     "dependencies": {
         "@mdx-js/loader": "^3.0.0",
@@ -34,6 +35,9 @@
         "postcss": "^8.4.25",
         "prettier": "3.3.2",
         "tailwindcss": "^3.3.2",
-        "typescript": "^5.2.2"
+        "typescript": "^5.2.2",
+        "@types/jest": "^29.5.11",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.1"
     }
 }


### PR DESCRIPTION
## Summary
- fix a typo in the Fluent Icons article
- merge MDX config properly in `next.config.js`
- update outdated comment in `lib/work.ts`
- add Jest configuration and a unit test for `getSortedWorkData`
- expose `npm test` script and add dev dependencies

## Testing
- `npm test` *(fails: jest not found)*